### PR TITLE
Fix Python 3.9 dependency resolution in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,8 @@ dependencies = [
     "pygelf>=0.4.2,<1.0.0",
     "requests>=2.32.3,<3.0.0",
     "tqdm>=4.31.1,<5.0.0",
-    "urllib3>=2.6.0,<3.0.0",
+    "urllib3>=1.25.7,<1.27; python_version < '3.10'",
+    "urllib3>=2.6.0,<3.0.0; python_version >= '3.10'",
     "xmltodict>=0.12.0,<1.0.0",
     "PyYAML>=6.0.3,<7.0.0"
 ]


### PR DESCRIPTION
## Summary
- fix dependency resolution for Python 3.9 by splitting `urllib3` constraints with environment markers
- keep modern `urllib3` for Python >= 3.10
- preserve compatibility with `botocore`/`boto3` on Python 3.9

## Root cause
The workflow failed in the `build (3.9)` job during `pip install .[build]` with `resolution-too-deep`.
This was caused by a dependency conflict between:
- `urllib3>=2.6.0,<3.0.0` (global constraint)
- transitive constraints from `botocore` on Python 3.9 (`urllib3<1.27`)

## Change
In `pyproject.toml`:
- replace single `urllib3` constraint with:
  - `urllib3>=1.25.7,<1.27; python_version < '3.10'`
  - `urllib3>=2.6.0,<3.0.0; python_version >= '3.10'`

## Impact
- fixes pip resolver failures on Python 3.9 CI jobs
- no runtime code changes
- no behavior change for Python >= 3.10

## Verification
- local install succeeds with updated constraints:
  - `.venv/bin/pip install -e .[build]`
- smoke test:
  - `.venv/bin/python -m pytest -q tests.py::Test::testBase64Decoding`
